### PR TITLE
Add basic .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Node dependencies
+node_modules/
+
+# Build output
+dist/
+
+# VS Code directory
+.vscode/
+
+# Logs and temp files
+*.log
+*.tmp
+*.temp
+
+# Misc
+.DS_Store
+Thumbs.db
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ npm run compile
 
 3. Press `F5` to launch a new Extension Development Host window.
 
+## How to Run
+
+1. Open this folder in VS Code.
+2. Follow the Setup steps above if you haven't already.
+3. Press `F5` (or choose **Run > Start Debugging**) to launch a new Extension Development Host.
+4. Use the command palette to try the Ink commands in the development window.
+
 ## Development
 
 The extension is written in TypeScript. The sidebar UI uses React and Tailwind CSS served via CDN so no additional build step is needed for styling.


### PR DESCRIPTION
## Summary
- keep build and dependency artifacts out of git
- add instructions for running the extension

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f5c47f1c083309f1ebdb72b170836